### PR TITLE
City & Category API. Change in url prefix convention.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 * [Product](apis/product.md)
 * [Inventory & Pricing](apis/inventory-pricing.md)
 * [Booking](apis/booking.md)
+* [City](apis/city.md)
+* [Category](apis/category.md)
 
 ## Object Models
 * [Common Models](object-models/common-models.md)

--- a/apis/booking.md
+++ b/apis/booking.md
@@ -66,7 +66,7 @@ List all bookings.
 		"creationTimestamp": 1491902295
 
 	}],
-	"nextUrl": "https://www.headout.com/api/v1/booking?offset=1&limit=1",
+	"nextUrl": "https://www.headout.com/api/public/v1/booking?offset=1&limit=1",
 	"prevUrl": null,
 	"total": 100,
 	"nextOffset": 1

--- a/apis/category.md
+++ b/apis/category.md
@@ -1,0 +1,42 @@
+# Category/Collection APIs
+
+**Resource path param:** `/category`
+
+## APIs
+
+METHOD | URL | AUTH | USAGE
+--- | --- | --- | ---
+GET | [`/category/list-by/city`](#GET-/category/list-by/city) | no | List all categories by city.
+
+### <a name="GET-/category/list-by/city"></a>GET `/category/list-by/city`
+
+List all categories by city.
+
+#### Request
+
+MODE | KEY | TYPE | OPTIONAL | DESCRIPTION
+--- | --- | --- | --- | ---
+QUERY | cityCode | string | no | The city code. Eg: `NEW_YORK`, `DUBAI`
+QUERY | offset | string | yes | The offset for pagination. *Ref: [Pagination - Request Params](/conventions/basics.md#Pagination--Request-Params)*
+QUERY | limit | int | yes | The limit for pagination. *Ref: [Pagination - Request Params](/conventions/basics.md#Pagination--Request-Params)*
+
+#### Response
+
+**Object:** [`category`](/object-models/category-models.md#category)
+
+```javascript
+{
+	"items": [
+		{
+			"id": "123",
+			"name": "Broadway",
+			"cityCode": "NEW_YORK",
+			"canonicalUrl": "https://www.headout.com/category/24/broadway"
+		}
+	],
+	"nextUrl": "https://www.headout.com/api/public/v1/category/list-by/city?cityCode=NEW_YORK,offset=21,limit=20",
+	"prevUrl": "https://www.headout.com/api/public/v1/category/list-by/city?cityCode=NEW_YORK,offset=0,limit=20",
+	"total": 100,
+	"nextOffset": 21
+}
+```

--- a/apis/city.md
+++ b/apis/city.md
@@ -1,0 +1,39 @@
+# City APIs
+
+**Resource path param:** `/city`
+
+## APIs
+
+METHOD | URL | AUTH | USAGE
+--- | --- | --- | ---
+GET | [`/city`](#GET-/city) | no | List all the active cities.
+
+### <a name="GET-/city"></a>GET `/city`
+
+List all the active cities.
+
+#### Request
+
+MODE | KEY | TYPE | OPTIONAL | DESCRIPTION
+--- | --- | --- | --- | ---
+QUERY | offset | string | yes | The offset for pagination. *Ref: [Pagination - Request Params](/conventions/basics.md#Pagination--Request-Params)*
+QUERY | limit | int | yes | The limit for pagination. *Ref: [Pagination - Request Params](/conventions/basics.md#Pagination--Request-Params)*
+
+#### Response
+
+**Object:** [`city`](/object-models/common-models.md#city)
+
+```javascript
+{
+	"items": [
+		{
+			"code": "NEW_YORK",
+			"name": "New York"
+		}
+	],
+	"nextUrl": "https://www.headout.com/api/public/v1/city?offset=21,limit=20",
+	"prevUrl": "https://www.headout.com/api/public/v1/city?offset=0,limit=20",
+	"total": 100,
+	"nextOffset": 21
+}
+```

--- a/apis/inventory-pricing.md
+++ b/apis/inventory-pricing.md
@@ -65,8 +65,8 @@ QUERY | currencyCode | string | yes | The currency in which pricing information 
 			}
 		}
 	],
-	"nextUrl": "https://www.headout.com/api/v1/inventory/list-by/variant?variantId=1234,offset=21,limit=20",
-	"prevUrl": "https://www.headout.com/api/v1/inventory/list-by/variant?variantId=1234,offset=0,limit=20",
+	"nextUrl": "https://www.headout.com/api/public/v1/inventory/list-by/variant?variantId=1234,offset=21,limit=20",
+	"prevUrl": "https://www.headout.com/api/public/v1/inventory/list-by/variant?variantId=1234,offset=0,limit=20",
 	"total": 100,
 	"nextOffset": 21
 }

--- a/apis/product.md
+++ b/apis/product.md
@@ -8,6 +8,7 @@ METHOD | URL | AUTH | USAGE
 --- | --- | --- | ---
 GET | [`/product/get/{product_id}`](#GET-/product/get/{product_id}) | no | Get product by `id`.
 GET | [`/product/listing/list-by/city`](#GET-/product/listing/list-by/city) | no | List product listing by city
+GET | [`/product/listing/list-by/category`](#GET-/product/listing/list-by/category) | no | List product listing by category
 
 ### <a name="GET-/product/get/{product_id}"></a>GET `/product/get/{product_id}`
 
@@ -163,7 +164,10 @@ QUERY | currencyCode | string | yes | The currency in which pricing information 
 			},
 			"neighbourhood": "Madison Square Garden",
 			"primaryCategory": {
-				"name": "Broadway"
+				"id": "123",
+				"name": "Broadway",
+				"cityCode": "NEW_YORK",
+				"canonicalUrl": "https://www.headout.com/category/24/broadway"
 			},
 			"startGeolocation": {
 				"latitude": 40.701568603515625,
@@ -184,8 +188,72 @@ QUERY | currencyCode | string | yes | The currency in which pricing information 
 			}
 		}
 	],
-	"nextUrl": "https://www.headout.com/api/v1/product/listing/list-by/city?cityCode=NEW_YORK,offset=21,limit=20",
-	"prevUrl": "https://www.headout.com/api/v1/product/listing/list-by/city?cityCode=NEW_YORK,offset=0,limit=20",
+	"nextUrl": "https://www.headout.com/api/public/v1/product/listing/list-by/city?cityCode=NEW_YORK,offset=21,limit=20",
+	"prevUrl": "https://www.headout.com/api/public/v1/product/listing/list-by/city?cityCode=NEW_YORK,offset=0,limit=20",
+	"total": 100,
+	"nextOffset": 21
+}
+```
+
+### <a name="GET-/product/listing/list-by/category"></a>GET `/product/listing/list-by/category`
+
+List product listing using category.
+
+#### Request
+
+MODE | KEY | TYPE | OPTIONAL | DESCRIPTION
+--- | --- | --- | --- | ---
+QUERY | categoryId | string | no | The id of the category.
+QUERY | offset | string | yes | The offset for pagination. *Ref: [Pagination - Request Params](/conventions/basics.md#Pagination--Request-Params)*
+QUERY | limit | int | yes | The limit for pagination. *Ref: [Pagination - Request Params](/conventions/basics.md#Pagination--Request-Params)*
+QUERY | currencyCode | string | yes | The currency in which pricing information will be returned. Eg: `USD`, `AED`. *Ref: [https://en.wikipedia.org/wiki/ISO_4217](https://en.wikipedia.org/wiki/ISO_4217)*
+
+#### Response
+
+**Object:** [`pagination-wrapper`](/object-models/common-models.md#pagination-wrapper)`<`[`product-listing`](/object-models/product-models.md#product-listing)`>`
+
+```javascript
+{
+	"items": [
+		{
+			"id": "Product ID",
+			"name": "Product Name",
+			"url": "https://product_url",
+			"city": {
+				"code": "NEW_YORK",
+				"displayName": "New York"
+			},
+			"image": {
+				"url": "https://imageurl"
+			},
+			"neighbourhood": "Madison Square Garden",
+			"primaryCategory": {
+				"id": "123",
+				"name": "Broadway",
+				"cityCode": "NEW_YORK",
+				"canonicalUrl": "https://www.headout.com/category/24/broadway"
+			},
+			"startGeolocation": {
+				"latitude": 40.701568603515625,
+				"longitude": -74.0091323852539
+			},
+			"ratingCumulative": {
+				"avg": 3.5,
+				"count": 5
+			},
+			"pricing": {
+			    "type": "PER_PERSON",
+			    "currencyCode": "AED",
+			    "minimumPrice": {
+			        "originalPrice": 551,
+			        "finalPrice": 518,
+			    }
+			    "bestDiscount": 28
+			}
+		}
+	],
+	"nextUrl": "https://www.headout.com/api/public/v1/product/listing/list-by/category?categoryId=23,offset=21,limit=20",
+	"prevUrl": "https://www.headout.com/api/public/v1/product/listing/list-by/category?categoryId=23,offset=0,limit=20",
 	"total": 100,
 	"nextOffset": 21
 }

--- a/conventions/basics.md
+++ b/conventions/basics.md
@@ -23,7 +23,10 @@ APIs run over `HTTPS`. If you specify `HTTP`, the url will be redirected to `HTT
 
 ### Url Prefix
 
-All APIs are prefixed with `/api/v{version_number}`. If the current version number is `1` then the your api prefix will be `/api/v1`.
+All APIs are prefixed with `/api/public/v{version_number}`. If the current version number is `1` then the your API prefix will be `/api/public/v1`. All previous APIs which worked under the previous paradigm of `/api/v{version_numer}` will still work but it is recommended to shift to the new url structure.
+
+##### Deprecated
+~~All APIs are prefixed with `/api/v{version_number}`. If the current version number is `1` then the your api prefix will be `/api/v1`.~~
 
 ## Authentication
 

--- a/object-models/category-models.md
+++ b/object-models/category-models.md
@@ -10,4 +10,7 @@ The category super object.
 
 KEY | TYPE | NULL/EMPTY | DESCRIPTION
 --- | --- | --- | ---
-name | string | no | The name of the category.
+id | string | no | The ID of the category.
+name | string | no | The display name of the category.
+cityCode | string | no | The city of the category. Eg: `NEW_YORK`, `DUBAI`
+canonicalUrl | string | no | The canonical url for the category page on `www.headout.com`. If a separate category page is being constructed for this category then you are required to add this url as canonical url in the HTML code using `<link rel="canonical">`. This url can also be used to open the concerned category page on `www.headout.com`.


### PR DESCRIPTION
API:
- Added City & Category API pages
- Added /city API
- Added /category/list-by/city API
- Added /product/listing/list-by/category API

Models:
- Modified `category` model to represent additional data.
	- Modified various response JS to reflect above.

Misc:
- Moved to `/api/public/v{version_number}` convention and deprecated /api/v{version_number}.
	- Modified various response JS to reflect above.